### PR TITLE
Internal code review of schedin implementation of [MJARSIGNER-72] Parallel signing for increased speed

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -286,7 +286,7 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
     }
 
     /**
-     * Finds all jar files, by looking at the Maven project configuration and user configuration.
+     * Finds all jar files, by looking at the Maven project and user configuration.
      *
      * @return a List of File objects
      * @throws MojoExecutionException if it was not possible to build a list of jar files.

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -354,11 +354,10 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
                 }
                 processed += numberOfprocessed.get();
 
-                
-//                for (File jarFile : jarFiles) {
-//                    processArchive(jarFile);
-//                    processed++;
-//                }
+                // for (File jarFile : jarFiles) {
+                //    processArchive(jarFile);
+                //    processed++;
+                // }
             }
         }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -357,11 +357,14 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            executor.shutdownNow();
             throw new MojoExecutionException("Thread interrupted while waiting for jarsigner to complete", e);
         } catch (ExecutionException e) {
+            executor.shutdownNow();
             if (e.getCause() instanceof MojoExecutionException) {
                 throw (MojoExecutionException) e.getCause();
             }
+            throw new MojoExecutionException("Error processing archives", e);
         } finally {
             executor.shutdown();
         }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -343,7 +343,7 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
     }
 
     void processArchives(List<File> archives) throws MojoExecutionException {
-        int threadCount = 2;
+        int threadCount = 2; // TODO: Replace this with threadCound parameter
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         List<Future<Void>> futures = archives.stream()
                 .map(file -> executor.submit((Callable<Void>) () -> {

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -177,7 +177,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         if (threadCount < 1) {
             getLog().warn(getMessage("invalidThreadCount", threadCount));
             threadCount = 1;
-        }        
+        }
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -123,9 +123,10 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private int maxRetryDelaySeconds;
 
     /**
-     * How many threads to use (in parallel) when signing jar files. This option may be desirable
-     * if any network operations are used during signing, for example using a Time Stamp Authority
-     * or network based PKCS11 HSM solution for storing code signing keys.
+     * How many threads to use (in parallel) when signing jar files. Increases performing when signing multiple jar
+     * files, especially when network operations are used during signing, for example when using a Time Stamp Authority
+     * or network based PKCS11 HSM solution for storing code signing keys. Note: the logging from the signing process
+     * will be interleaved, and harder to read, when using many threads.
      *
      * @since 3.1.0
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -115,6 +115,16 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.maxRetryDelaySeconds", defaultValue = "0")
     private int maxRetryDelaySeconds;
 
+    /**
+     * How many threads to use (in parallel) when signing jar files. This option may be desirable
+     * if any network operations are used during signing, for example using a Time Stamp Authority
+     * or network based PKCS11 HSM solution for storing code signing keys.
+     *
+     * @since 3.1.0
+     */
+    @Parameter(property = "jarsigner.threadCount", defaultValue = "1")
+    private int threadCount;
+
     /** Current WaitStrategy, to allow for sleeping after a signing failure. */
     private WaitStrategy waitStrategy = this::defaultWaitStrategy;
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -173,6 +173,11 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             getLog().warn(getMessage("invalidMaxRetryDelaySeconds", maxRetryDelaySeconds));
             maxRetryDelaySeconds = 0;
         }
+
+        if (threadCount < 1) {
+            getLog().warn(getMessage("invalidThreadCount", threadCount));
+            threadCount = 1;
+        }        
     }
 
     /**
@@ -192,9 +197,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Processing of files may be parallelized for increased performance.
+     * {@inheritDoc} Processing of files may be parallelized for increased performance.
      */
     @Override
     protected void processArchives(List<File> archives) throws MojoExecutionException {

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -123,7 +123,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private int maxRetryDelaySeconds;
 
     /**
-     * How many threads to use (in parallel) when signing jar files. Increases performing when signing multiple jar
+     * How many threads to use (in parallel) when signing jar files. Increases performance when signing multiple jar
      * files, especially when network operations are used during signing, for example when using a Time Stamp Authority
      * or network based PKCS11 HSM solution for storing code signing keys. Note: the logging from the signing process
      * will be interleaved, and harder to read, when using many threads.

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -210,20 +210,19 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
                 .collect(Collectors.toList());
         try {
             for (Future<Void> future : futures) {
-                future.get(); // Wait for completion, ignore result but expose any Exception
+                future.get(); // Wait for completion. Result ignored, but may raise any Exception
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            executor.shutdownNow();
             throw new MojoExecutionException("Thread interrupted while waiting for jarsigner to complete", e);
         } catch (ExecutionException e) {
-            executor.shutdownNow();
             if (e.getCause() instanceof MojoExecutionException) {
                 throw (MojoExecutionException) e.getCause();
             }
             throw new MojoExecutionException("Error processing archives", e);
         } finally {
-            executor.shutdown();
+            // Shutdown of executing threads. If an Exception occurred, remaining threads will be aborted "best effort"
+            executor.shutdownNow();
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -221,7 +221,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             }
             throw new MojoExecutionException("Error processing archives", e);
         } finally {
-            // Shutdown of executing threads. If an Exception occurred, remaining threads will be aborted "best effort"
+            // Shutdown of thread pool. If an Exception occurred, remaining threads will be aborted "best effort"
             executor.shutdownNow();
         }
     }

--- a/src/main/resources/jarsigner.properties
+++ b/src/main/resources/jarsigner.properties
@@ -26,3 +26,4 @@ failure = Failed executing ''{0}'' - exitcode {1,number}
 archiveNotSigned = Archive ''{0}'' is not signed
 invalidMaxTries = Invalid maxTries value. Was ''{0}'' but should be >= 1
 invalidMaxRetryDelaySeconds = Invalid maxRetryDelaySeconds value. Was ''{0}'' but should be >= 0
+invalidThreadCount = Invalid threadCount value. Was ''{0}'' but should be >= 1

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -185,7 +185,7 @@ public class JarsignerSignMojoParallelTest {
             mojo.execute();
         });
 
-        assertThat(mojoException.getMessage(), containsString(String.valueOf("Some error")));
+        assertThat(mojoException.getMessage(), containsString(String.valueOf("Failed executing 'jarsigner ")));
     }
 
     private File createArchives(int numberOfArchives) throws IOException {

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -111,7 +111,7 @@ public class JarsignerSignMojoParallelTest {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "2");
 
-        // Make three jar files wait until some external event happens and let eight pass
+        // Make three jar files wait until some external event happens and let seven pass
         Semaphore semaphore = new Semaphore(7);
         when(jarSigner.execute(isA(JarSignerSignRequest.class))).then(invocation -> {
             semaphore.acquire();
@@ -124,13 +124,13 @@ public class JarsignerSignMojoParallelTest {
             return null;
         });
 
-        // Wait until 9 invocation to execute has happened (2 is ongoing and 1 has not yet happened)
+        // Wait until 9 invocations to execute has happened (2 is ongoing and 1 has not yet happened)
         verify(jarSigner, timeout(Duration.ofSeconds(10).toMillis()).times(9)).execute(any());
         assertFalse(future.isDone());
 
         semaphore.release(); // Release one waiting jar file
 
-        // Wait until 10 invocation to execute has happened (8 files are done and 2 are hanging)
+        // Wait until 10 invocation to execute has happened (8 are done and 2 are hanging)
         verify(jarSigner, timeout(Duration.ofSeconds(10).toMillis()).times(10)).execute(any());
 
         semaphore.release(2); // Release last two jar files

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -116,7 +116,7 @@ public class JarsignerSignMojoParallelTest {
             JarSignerSignRequest request = (JarSignerSignRequest) invocation.getArgument(0);
             // Make one jar file wait until some external event happens
             if (request.getArchive().getPath().endsWith("archive2.jar") || request.getArchive().getPath().endsWith("archive3.jar")) {
-                latch.await();
+                latch.await(); //TODO: This does not work. Switch to Semaphore
             }
             return RESULT_OK;
         });

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.hamcrest.MockitoHamcrest;
+import org.mockito.stubbing.Answer;
+
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JarsignerSignMojoParallelTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private MavenProject project = mock(MavenProject.class);
+    private JarSigner jarSigner = mock(JarSigner.class);
+    private File projectDir;
+    private Map<String, String> configuration = new LinkedHashMap<>();
+    private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        projectDir = folder.newFolder("dummy-project");
+        mojoTestCreator =
+                new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
+        executor = Executors.newSingleThreadExecutor(namedThreadFactory(getClass().getSimpleName()));
+    }
+    
+    @After
+    public void tearDown() {
+        executor.shutdown();
+    }    
+
+    @Test(timeout = 600000) // TODO: change timeout before merge
+    public void test10Files2Parallel() throws Exception {
+        File archiveDirectory = new File(projectDir, "my_archive_dir");
+        archiveDirectory.mkdir();
+
+        for (int i = 0; i < 10; i++) {
+            TestArtifacts.createDummyZipFile(new File(archiveDirectory, "archive" + i + ".jar"));
+        }
+
+        configuration.put("processMainArtifact", "false");
+        configuration.put("archiveDirectory", archiveDirectory.getPath());
+        configuration.put("threadCount", "2");
+
+        when(jarSigner.execute(isA(JarSignerSignRequest.class))).then(invocation -> {
+            Object a = invocation.getArgument(0);
+            System.out.println(a);
+            return RESULT_OK;
+        });
+
+        configuration.put("threadCount", "2");
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        Future<Void> future = executor.submit(() -> {
+            mojo.execute();
+            return null;
+        });
+
+
+        
+        
+        
+        future.get(600, TimeUnit.SECONDS); // TODO: change timeout before merge
+        //executor.shutdown();
+        //executor.awaitTermination(20, TimeUnit.SECONDS);
+        verify(jarSigner, times(10)).execute(any());
+        
+    }
+
+    private static ThreadFactory namedThreadFactory(String threadNamePrefix) {
+        return r -> new Thread(r, threadNamePrefix + "-Thread");
+    }    
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -78,7 +78,7 @@ public class JarsignerSignMojoParallelTest {
         executor.shutdown();
     }
 
-    @Test(timeout = 300000) // TODO: change timeout before merge
+    @Test(timeout = 30000)
     public void test10Files2Parallel() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "2");
@@ -97,16 +97,16 @@ public class JarsignerSignMojoParallelTest {
         });
 
         // Wait until 10 invocation to execute has happened (nine files are done and one are hanging)
-        verify(jarSigner, timeout(Duration.ofSeconds(100).toMillis()).times(10)).execute(any());
+        verify(jarSigner, timeout(Duration.ofSeconds(10).toMillis()).times(10)).execute(any());
         // Even though 10 invocations to execute() has happened, mojo is not yet done executing (it is waiting for one)
         assertFalse(future.isDone());
 
         semaphore.release(); // Release the one waiting jar file
-        future.get(100, TimeUnit.SECONDS); // Wait for entire Mojo to finish
+        future.get(10, TimeUnit.SECONDS); // Wait for entire Mojo to finish
         assertTrue(future.isDone());
     }
 
-    @Test(timeout = 30000) // TODO: change timeout before merge
+    @Test(timeout = 30000)
     public void test10Files2Parallel3Hanging() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "2");
@@ -138,7 +138,7 @@ public class JarsignerSignMojoParallelTest {
         assertTrue(future.isDone());
     }
 
-    @Test(timeout = 30000) // TODO: change timeout before merge
+    @Test(timeout = 30000)
     public void test10Files1Parallel() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "1");

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -62,7 +62,7 @@ public class JarsignerSignMojoRetryTest {
     private MavenProject project = mock(MavenProject.class);
     private JarSigner jarSigner = mock(JarSigner.class);
     private WaitStrategy waitStrategy = mock(WaitStrategy.class);
-    private File dummyMavenProjectDir;
+    private File projectDir;
     private Map<String, String> configuration = new LinkedHashMap<>();
     private Log log;
     private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
@@ -71,12 +71,12 @@ public class JarsignerSignMojoRetryTest {
     public void setUp() throws Exception {
         originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
-        dummyMavenProjectDir = folder.newFolder("dummy-project");
-        mojoTestCreator = new MojoTestCreator<JarsignerSignMojo>(
-                JarsignerSignMojo.class, project, dummyMavenProjectDir, jarSigner);
+        projectDir = folder.newFolder("dummy-project");
+        mojoTestCreator =
+                new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);
         mojoTestCreator.setLog(log);
-        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
         when(project.getArtifact()).thenReturn(mainArtifact);
     }
 

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
@@ -34,6 +35,7 @@ import org.apache.maven.shared.jarsigner.JarSignerUtil;
 import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,6 +63,7 @@ public class JarsignerSignMojoTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
+    private Locale originalLocale;
     private MavenProject project = mock(MavenProject.class);
     private JarSigner jarSigner = mock(JarSigner.class);
     private File projectDir;
@@ -70,11 +73,18 @@ public class JarsignerSignMojoTest {
 
     @Before
     public void setUp() throws Exception {
+        originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
         projectDir = folder.newFolder("dummy-project");
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);
         mojoTestCreator.setLog(log);
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(originalLocale);
     }
 
     /** Standard Java project with nothing special configured */
@@ -400,5 +410,17 @@ public class JarsignerSignMojoTest {
         verify(jarSigner)
                 .execute(MockitoHamcrest.argThat(
                         RequestMatchers.hasArguments(new String[] {"-J-Dfile.encoding=ISO-8859-1", "argument2"})));
+    }
+
+    /** TODO */
+    @Test
+    public void testLoggingVerboseTrue() throws Exception {
+        // TODO
+    }
+
+    /** TODO */
+    @Test
+    public void testLoggingVerboseFalse() throws Exception {
+        // TODO
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -437,7 +437,7 @@ public class JarsignerSignMojoTest {
         verify(log, times(1)).info(contains("Unsupported artifact "));
         verify(log, times(1)).info(contains("Forcibly ignoring attached artifacts"));
         verify(log, times(1)).info(contains("Processing "));
-        verify(log, times(1)).info(contains("0 archive(s) processed"));
+        verify(log, times(1)).info(contains("1 archive(s) processed"));
     }
 
     /** Test what is logged when verbose=false */
@@ -460,6 +460,6 @@ public class JarsignerSignMojoTest {
         verify(log, times(1)).debug(contains("Unsupported artifact "));
         verify(log, times(1)).debug(contains("Forcibly ignoring attached artifacts"));
         verify(log, times(1)).debug(contains("Processing "));
-        verify(log, times(1)).info(contains("0 archive(s) processed"));
+        verify(log, times(1)).info(contains("1 archive(s) processed"));
     }
 }


### PR DESCRIPTION
This is an "internal" pull request/code review so that the code can be review by my colleague before a real pull request is created for the https://github.com/apache/maven-jarsigner-plugin project. In practice it is public, since I cloned the repo.

In this pull request I have implemented https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-72 so that signing of jar files can be done in parallel.

This ticket is the reason I added to many test cases in my previous work of implementing MJARSIGNER-41. In the scope of this ticket I have added new test cases to verify that the threading/parallelism works. I have also added some logging tests (to verify that the logging is correctly handled).

