### PR TITLE
[MJARSIGNER-74] Allow usage of multiple Time Stamping Authority (TSA) servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-jarsigner</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -155,10 +155,10 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
      * <pre>
      * {@code
      * <configuration>
-     *     <arguments>
-     *         <argument>-signedjar</argument>
-     *         <argument>my-project_signed.jar</argument>
-     *     </arguments>
+     *   <arguments>
+     *     <argument>-signedjar</argument>
+     *     <argument>my-project_signed.jar</argument>
+     *   </arguments>
      * </configuration>
      * }</pre>
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -76,9 +76,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /**
      * <p>URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
-     * </p>
-     *
-     * <p>Separate multiple TSA URLs with comma (without space) or a nested XML tag.</p>
+     * Separate multiple TSA URLs with comma (without space) or a nested XML tag.</p>
      *
      * <pre>{@code
      * <configuration>
@@ -108,9 +106,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /**
      * <p>Alias(es) for certificate(s) in the active keystore used to find a TSA URL. From the certificate the X509v3
      * extension "Subject Information Access" field is examined to find the TSA server URL. See
-     * <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.</p>
-     *
-     * <p>Separate multiple aliases with comma (without space) or a nested XML tag.</p>
+     * <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * Separate multiple aliases with comma (without space) or a nested XML tag.</p>
      *
      * <pre>{@code
      * <configuration>
@@ -143,9 +140,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /**
      * <p>OID(s) to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
      * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs. See
-     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.</p>
-     *
-     * <p>Separate multiple OIDs with comma (without space) or a nested XML tag.</p>
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
+     * Separate multiple OIDs with comma (without space) or a nested XML tag.</p>
      *
      * <pre>{@code
      * <configuration>

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -84,10 +84,10 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /**
      * <p>Alias(es) for a certificate in the active keystore used to find a TSA URL. From the certificate the X509v3
      * extension "Subject Information Access" field is examined to find the TSA server URL.</p>
-     * 
+     *
      * <p>Should not be used at the same time as the {@link #tsa} parameter (because jarsigner will typically ignore
      * tsacert, if tsa is set.</p>
-     * 
+     *
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
      *
      * @since 1.3
@@ -98,7 +98,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /**
      * An OID to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
      * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs.
-     * 
+     *
      * See
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      *
@@ -108,11 +108,13 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private String tsapolicyid;
 
     /**
-     * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. For example {@code SHA-384}.
-     * "SHA-384". Only available in Java 11 and later. See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
+     * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. For example
+     * {@code SHA-384}. A default value will be selected by jarsigner if this parameter is not set. Only available in
+     * Java 11 and later. See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
      *
      * @since 3.1.0
      */
+    @Parameter(property = "jarsigner.tsadigestalg")
     private String tsadigestalg;
 
     /**
@@ -214,6 +216,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         request.setTsaLocation(tsa);
         request.setTsaAlias(tsacert);
         request.setCertchain(certchain);
+        request.setTsapolicyid(tsapolicyid);
+        request.setTsadigestalg(tsadigestalg);
 
         // Special handling for passwords through the Maven Security Dispatcher
         request.setKeypass(decrypt(keypass));

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -100,7 +100,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private String[] tsacert;
 
     /**
-     * An OID to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
+     * OID(s) to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
      * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs.
      *
      * See
@@ -109,7 +109,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
      * @since 3.1.0
      */
     @Parameter(property = "jarsigner.tsapolicyid")
-    private String tsapolicyid;
+    private String[] tsapolicyid;
 
     /**
      * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. For example
@@ -224,7 +224,9 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             request.setTsaAlias(tsacert[0]);
         }
         request.setCertchain(certchain);
-        request.setTsapolicyid(tsapolicyid);
+        if (tsapolicyid != null && tsapolicyid.length > 0) {
+            request.setTsapolicyid(tsapolicyid[0]);
+        }
         request.setTsadigestalg(tsadigestalg);
 
         // Special handling for passwords through the Maven Security Dispatcher

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -73,6 +73,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private boolean removeExistingSignatures;
 
     /**
+     * URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
      *
      * @since 1.3
@@ -81,12 +82,38 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private String tsa;
 
     /**
+     * <p>Alias(es) for a certificate in the active keystore used to find a TSA URL. From the certificate the X509v3
+     * extension "Subject Information Access" field is examined to find the TSA server URL.</p>
+     * 
+     * <p>Should not be used at the same time as the {@link #tsa} parameter (because jarsigner will typically ignore
+     * tsacert, if tsa is set.</p>
+     * 
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
      *
      * @since 1.3
      */
     @Parameter(property = "jarsigner.tsacert")
     private String tsacert;
+
+    /**
+     * An OID to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
+     * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs.
+     * 
+     * See
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
+     *
+     * @since 3.1.0
+     */
+    @Parameter(property = "jarsigner.tsapolicyid")
+    private String tsapolicyid;
+
+    /**
+     * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. For example {@code SHA-384}.
+     * "SHA-384". Only available in Java 11 and later. See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
+     *
+     * @since 3.1.0
+     */
+    private String tsadigestalg;
 
     /**
      * Location of the extra certificate chain file. See

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -276,7 +276,10 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
                 return;
             }
             if (attempt < maxTries - 1) { // If not last attempt
+                // TODO indicate error for the TsaServer
                 waitStrategy.waitAfterFailure(attempt, Duration.ofSeconds(maxRetryDelaySeconds));
+                // TODO select a new TsaServer
+                
             } else {
                 // Last attempt failed, use this failure as resulting failure
                 throw new MojoExecutionException(getMessage("failure", getCommandlineInfo(commandLine), resultCode));

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.jarsigner.TsaSelector.TsaServer;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerRequest;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
@@ -221,13 +222,22 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     protected JarSignerRequest createRequest(File archive) throws MojoExecutionException {
         JarSignerSignRequest request = new JarSignerSignRequest();
         request.setSigfile(sigfile);
-        tsaSelector.updateTsaParameters(request);
+        updateJarSignerRequestWithTsa(request, tsaSelector.getNext());
+        request.setCertchain(certchain);
 
         // Special handling for passwords through the Maven Security Dispatcher
         request.setKeypass(decrypt(keypass));
         return request;
     }
 
+    /** Modifies JarSignerRequest with TSA parameters */
+    private void updateJarSignerRequestWithTsa(JarSignerSignRequest request, TsaServer tsaServer) {
+        request.setTsaLocation(tsaServer.getTsaUrl());
+        request.setTsaAlias(tsaServer.getTsaAlias());
+        request.setTsapolicyid(tsaServer.getTsaPolicyId());
+        request.setTsadigestalg(tsaServer.getTsaDigestAlt());
+    }
+    
     /**
      * {@inheritDoc} Processing of files may be parallelized for increased performance.
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -76,24 +76,28 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
      * URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
      *
+     * <p>Changed to a list since 3.1.0</p>
+     *
      * @since 1.3
      */
     @Parameter(property = "jarsigner.tsa")
-    private String tsa;
+    private String[] tsa;
 
     /**
      * <p>Alias(es) for a certificate in the active keystore used to find a TSA URL. From the certificate the X509v3
      * extension "Subject Information Access" field is examined to find the TSA server URL.</p>
      *
      * <p>Should not be used at the same time as the {@link #tsa} parameter (because jarsigner will typically ignore
-     * tsacert, if tsa is set.</p>
+     * tsacert, if tsa is set).</p>
      *
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     *
+     * <p>Changed to a list since 3.1.0</p>
      *
      * @since 1.3
      */
     @Parameter(property = "jarsigner.tsacert")
-    private String tsacert;
+    private String[] tsacert;
 
     /**
      * An OID to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
@@ -213,8 +217,12 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     protected JarSignerRequest createRequest(File archive) throws MojoExecutionException {
         JarSignerSignRequest request = new JarSignerSignRequest();
         request.setSigfile(sigfile);
-        request.setTsaLocation(tsa);
-        request.setTsaAlias(tsacert);
+        if (tsa != null && tsa.length > 0) {
+            request.setTsaLocation(tsa[0]);
+        }
+        if (tsacert != null && tsacert.length > 0) {
+            request.setTsaAlias(tsacert[0]);
+        }
         request.setCertchain(certchain);
         request.setTsapolicyid(tsapolicyid);
         request.setTsadigestalg(tsadigestalg);

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -292,7 +292,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             } else {
                 // Last attempt failed, use this failure as resulting failure
                 throw new MojoExecutionException(
-                    getMessage("failure", getCommandlineInfo(result.getCommandline()), resultCode));
+                        getMessage("failure", getCommandlineInfo(result.getCommandline()), resultCode));
             }
         }
     }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -73,6 +73,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.removeExistingSignatures", defaultValue = "false")
     private boolean removeExistingSignatures;
 
+    // TODO: fix documentation
     /**
      * URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
@@ -84,6 +85,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.tsa")
     private String[] tsa;
 
+    // TODO: fix documentation
     /**
      * <p>Alias(es) for a certificate in the active keystore used to find a TSA URL. From the certificate the X509v3
      * extension "Subject Information Access" field is examined to find the TSA server URL.</p>
@@ -100,6 +102,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.tsacert")
     private String[] tsacert;
 
+    // TODO: fix documentation
     /**
      * OID(s) to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
      * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs.
@@ -211,7 +214,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             getLog().warn(getMessage("invalidThreadCount", threadCount));
             threadCount = 1;
         }
-
+        // TODO: fix validation
         tsaSelector = new TsaSelector(tsa, tsacert, tsapolicyid, tsadigestalg);
     }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -211,7 +211,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             getLog().warn(getMessage("invalidThreadCount", threadCount));
             threadCount = 1;
         }
-        
+
         tsaSelector = new TsaSelector(tsa, tsacert, tsapolicyid, tsadigestalg);
     }
 
@@ -237,7 +237,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         request.setTsapolicyid(tsaServer.getTsaPolicyId());
         request.setTsadigestalg(tsaServer.getTsaDigestAlt());
     }
-    
+
     /**
      * {@inheritDoc} Processing of files may be parallelized for increased performance.
      */
@@ -285,7 +285,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
                 return;
             }
             tsaSelector.registerFailure(); // Could be TSA server problem or something unrelated to TSA
-            
+
             if (attempt < maxTries - 1) { // If not last attempt
                 waitStrategy.waitAfterFailure(attempt, Duration.ofSeconds(maxRetryDelaySeconds));
                 updateJarSignerRequestWithTsa((JarSignerSignRequest) request, tsaSelector.getServer());

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -96,7 +96,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
      * <p>Usage of multiple TSA servers only makes sense when {@link #maxTries} is more than 1. A different TSA server
      * will only be used at retries.</p>
      *
-     * <p>Changed to a list since 3.1.0. Single element (without comma) is still supported.</p>
+     * <p>Changed to a list since 3.1.0. Single XML element (without comma) is still supported.</p>
      *
      * @since 1.3
      */
@@ -130,7 +130,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
      * <p>Usage of multiple aliases only makes sense when {@link #maxTries} is more than 1. A different TSA server
      * will only be used at retries.</p>
      *
-     * <p>Changed to a list since 3.1.0. Single element (without comma) is still supported.</p>
+     * <p>Changed to a list since 3.1.0. Single XML element (without comma) is still supported.</p>
      *
      * @since 1.3
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -167,8 +167,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     private String[] tsapolicyid;
 
     /**
-     * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. For example
-     * {@code SHA-384}. A default value will be selected by jarsigner if this parameter is not set. Only available in
+     * The message digest algorithm to use in the messageImprint that the TSA server will timestamp. A default value
+     * (for example {@code SHA-384}) will be selected by jarsigner if this parameter is not set. Only available in
      * Java 11 and later. See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
      *
      * @since 3.1.0

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -269,7 +269,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         if (tsa.length > 0 && tsacert.length > 0) {
             getLog().warn(getMessage("warnUsageTsaAndTsacertSimultaneous"));
         }
-        if (tsapolicyid.length > tsa.length || tsapolicyid.length > tsacert.length ) {
+        if (tsapolicyid.length > tsa.length || tsapolicyid.length > tsacert.length) {
             getLog().warn(getMessage("warnUsageTsapolicyidTooMany", tsapolicyid.length, tsa.length, tsacert.length));
         }
         if (tsa.length > 1 && maxTries == 1) {

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -73,42 +73,97 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.removeExistingSignatures", defaultValue = "false")
     private boolean removeExistingSignatures;
 
-    // TODO: fix documentation
     /**
-     * URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
+     * <p>URL(s) to Time Stamping Authority (TSA) server(s) to use to timestamp the signing.
      * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * </p>
      *
-     * <p>Changed to a list since 3.1.0</p>
+     * <p>Separate multiple TSA URLs with comma (without space) or a nested XML tag.</p>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsa>http://timestamp.digicert.com,http://timestamp.globalsign.com/tsa/r6advanced1</tsa>
+     * </configuration>
+     * }</pre>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsa>
+     *     <url>http://timestamp.digicert.com</url>
+     *     <url>http://timestamp.globalsign.com/tsa/r6advanced1</url>
+     *   </tsa>
+     * </configuration>
+     * }</pre>
+     *
+     * <p>Usage of multiple TSA servers only makes sense when {@link #maxTries} is more than 1. A different TSA server
+     * will only be used at retries.</p>
+     *
+     * <p>Changed to a list since 3.1.0. Single element (without comma) is still supported.</p>
      *
      * @since 1.3
      */
     @Parameter(property = "jarsigner.tsa")
     private String[] tsa;
 
-    // TODO: fix documentation
     /**
-     * <p>Alias(es) for a certificate in the active keystore used to find a TSA URL. From the certificate the X509v3
-     * extension "Subject Information Access" field is examined to find the TSA server URL.</p>
+     * <p>Alias(es) for certificate(s) in the active keystore used to find a TSA URL. From the certificate the X509v3
+     * extension "Subject Information Access" field is examined to find the TSA server URL. See
+     * <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.</p>
+     *
+     * <p>Separate multiple aliases with comma (without space) or a nested XML tag.</p>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsacert>alias1,alias2</tsacert>
+     * </configuration>
+     * }</pre>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsacert>
+     *     <alias>alias1</alias>
+     *     <alias>alias2</alias>
+     *   </tsacert>
+     * </configuration>
+     * }</pre>
      *
      * <p>Should not be used at the same time as the {@link #tsa} parameter (because jarsigner will typically ignore
      * tsacert, if tsa is set).</p>
      *
-     * See <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * <p>Usage of multiple aliases only makes sense when {@link #maxTries} is more than 1. A different TSA server
+     * will only be used at retries.</p>
      *
-     * <p>Changed to a list since 3.1.0</p>
+     * <p>Changed to a list since 3.1.0. Single element (without comma) is still supported.</p>
      *
      * @since 1.3
      */
     @Parameter(property = "jarsigner.tsacert")
     private String[] tsacert;
 
-    // TODO: fix documentation
     /**
-     * OID(s) to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
-     * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs.
+     * <p>OID(s) to send to the TSA server to identify the policy ID the server should use. If not specified TSA server
+     * will choose a default policy ID. Each TSA server vendor will typically define their own policy OIDs. See
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.</p>
      *
-     * See
-     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
+     * <p>Separate multiple OIDs with comma (without space) or a nested XML tag.</p>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsapolicyid>1.3.6.1.4.1.4146.2.3.1.2,2.16.840.1.114412.7.1</tsapolicyid>
+     * </configuration>
+     * }</pre>
+     *
+     * <pre>{@code
+     * <configuration>
+     *   <tsapolicyid>
+     *     <oid>1.3.6.1.4.1.4146.2.3.1.2</oid>
+     *     <oid>2.16.840.1.114412.7.1</oid>
+     *   </tsapolicyid>
+     * </configuration>
+     * }</pre>
+     *
+     * <p>If used, the number of OIDs should be the same as the number of elements in {@link #tsa} or {@link #tsacert}.
+     * The first OID will be used for the first TSA server, the second OID for the second TSA server and so on.</p>
      *
      * @since 3.1.0
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -265,7 +265,19 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
             getLog().warn(getMessage("invalidThreadCount", threadCount));
             threadCount = 1;
         }
-        // TODO: fix validation
+
+        if (tsa.length > 0 && tsacert.length > 0) {
+            getLog().warn(getMessage("warnUsageTsaAndTsacertSimultaneous"));
+        }
+        if (tsapolicyid.length > tsa.length || tsapolicyid.length > tsacert.length ) {
+            getLog().warn(getMessage("warnUsageTsapolicyidTooMany", tsapolicyid.length, tsa.length, tsacert.length));
+        }
+        if (tsa.length > 1 && maxTries == 1) {
+            getLog().warn(getMessage("warnUsageMultiTsaWithoutRetry", tsa.length));
+        }
+        if (tsacert.length > 1 && maxTries == 1) {
+            getLog().warn(getMessage("warnUsageMultiTsacertWithoutRetry", tsacert.length));
+        }
         tsaSelector = new TsaSelector(tsa, tsacert, tsapolicyid, tsadigestalg);
     }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -18,16 +18,19 @@
  */
 package org.apache.maven.plugins.jarsigner;
 
-import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Helper class to select a Time Stamping Authority (TSA) server along with parameters to send. The protocol is defined
  * in RFC 3161: Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP).
- * 
+ *
  * From a jarsigner perspective there are two things that are important:
  * 1. Finding a TSA server URL
  * 2. What parameters to use for TSA server communication.
- * 
+ *
  * Finding a URL can be done in two ways:
  * a) The end-user has specified an explicit URL (the most common way)
  * b) The end-user has specified a keystore alias that points to a certificate in the active keystore. From the
@@ -38,37 +41,89 @@ import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
  *    Subject Information Access:
  *        AD Time Stamping - URI:http://timestamp.globalsign.com/tsa/r6advanced1
  *    </pre>
- * 
+ *
  * Each TSA server vendor typically has defined its own OID for what "policy" to use in the timestamping process. For
  * example GlobalSign might use 1.3.6.1.4.1.4146.2.3.1.2. A DigiCert TSA server would not accept this OID. In most cases
  * there is no need for the end-user to specify this because the TSA server will choose a default.
- * 
+ *
  * jarsigner will send a message digest to the TSA server along with the message digest algorithm. For example
  * {@code SHA-384}. A TSA server might reject the chosen algorithm, but typically most TSA servers supports the "common"
  * ones (like SHA-256, SHA-384 and SHA-512). In most cases there is no need for the end-user to specify this because the
  * jarsigner tool choose a good default.
  */
 class TsaSelector {
-    
+
+    /** The current TsaServer in use (if any). One per thread */
+    private final ThreadLocal<TsaServer> currentTsaServer = new ThreadLocal<>();
+
+    /** List of TSA servers. Will at minimum contain a dummy value */
+    private final List<TsaServer> tsaServers;
+
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
-        
+        List<TsaServer> tsaServersTmp = new ArrayList<>();
+
+        this.tsaServers = Collections.unmodifiableList(tsaServersTmp);
     }
 
-    private void updateTsaParameters(JarSignerSignRequest request) {
-        if (tsa != null && tsa.length > 0) {
-            request.setTsaLocation(tsa[0]);
-        }
-        if (tsacert != null && tsacert.length > 0) {
-            request.setTsaAlias(tsacert[0]);
-        }
-        request.setCertchain(certchain);
-        if (tsapolicyid != null && tsapolicyid.length > 0) {
-            request.setTsapolicyid(tsapolicyid[0]);
-        }
-        request.setTsadigestalg(tsadigestalg);
+//    private void updateTsaParameters(JarSignerSignRequest request) {
+//        if (tsa != null && tsa.length > 0) {
+//            request.setTsaLocation(tsa[0]);
+//        }
+//        if (tsacert != null && tsacert.length > 0) {
+//            request.setTsaAlias(tsacert[0]);
+//        }
+//        request.setCertchain(certchain);
+//        if (tsapolicyid != null && tsapolicyid.length > 0) {
+//            request.setTsapolicyid(tsapolicyid[0]);
+//        }
+//        request.setTsadigestalg(tsadigestalg);
+//    }
+
+    /**
+     * Gets the next "best" TSA server to use.
+     */
+    public TsaServer getServer() {
+        // TODO Auto-generated method stub
+        return null;
     }
+
+    public void registerFailure() {
+        if (currentTsaServer.get() != null) {
+            currentTsaServer.get().failureCount.incrementAndGet();
+        }
+    }
+
     /** Representation of a single TSA server and the parameters to use for it */
-    class TsaServer {
-        
+    static class TsaServer {
+        private static TsaServer EMPTY = new TsaServer(null, null, null, null);
+
+        private final AtomicInteger failureCount = new AtomicInteger(0);
+        private final String tsaUrl;
+        private final String tsaAlias;
+        private final String tsaPolicyId;
+        private final String tsaDigestAlt;
+
+        private TsaServer(String tsaUrl, String tsaAlias, String tsaPolicyId, String tsaDigestAlt) {
+            this.tsaUrl = tsaUrl;
+            this.tsaAlias = tsaAlias;
+            this.tsaPolicyId = tsaPolicyId;
+            this.tsaDigestAlt = tsaDigestAlt;
+        }
+
+        public String getTsaUrl() {
+            return tsaUrl;
+        }
+
+        public String getTsaAlias() {
+            return tsaAlias;
+        }
+
+        public String getTsaPolicyId() {
+            return tsaPolicyId;
+        }
+
+        public String getTsaDigestAlt() {
+            return tsaDigestAlt;
+        }
     }
 }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -61,7 +61,6 @@ class TsaSelector {
 
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
         List<TsaServer> tsaServersTmp = new ArrayList<>();
-
         this.tsaServers = Collections.unmodifiableList(tsaServersTmp);
     }
 
@@ -107,7 +106,7 @@ class TsaSelector {
 
     /** Representation of a single TSA server and the parameters to use for it */
     static class TsaServer {
-        private static TsaServer EMPTY = new TsaServer(null, null, null, null);
+        private static final TsaServer EMPTY = new TsaServer(null, null, null, null);
 
         private final AtomicInteger failureCount = new AtomicInteger(0);
         private final String tsaUrl;

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+class TsaSelector {
+    
+    TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
+        
+    }
+
+}

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -86,14 +86,14 @@ class TsaSelector {
      * server, but good enough.
      */
     TsaServer getServer() {
-        TsaServer bestTsaServer = tsaServers.get(0);
+        TsaServer best = tsaServers.get(0);
         for (int i = 1; i < tsaServers.size(); i++) {
-            if (bestTsaServer.failureCount.get() > tsaServers.get(i).failureCount.get()) {
-                bestTsaServer = tsaServers.get(i);
+            if (best.failureCount.get() > tsaServers.get(i).failureCount.get()) {
+                best = tsaServers.get(i);
             }
         }
-        currentTsaServer.set(bestTsaServer);
-        return bestTsaServer;
+        currentTsaServer.set(best);
+        return best;
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -66,28 +66,18 @@ class TsaSelector {
         
         List<TsaServer> tsaServersTmp = new ArrayList<>();
         
-        for (int i == 0; i < ) // TODO
-        
-        
+        for (int i = 0; i < Math.max(tsa.length, tsacert.length); i++) {
+            String tsaUrl = i < tsa.length ? tsa[i] : null;
+            String tsaAlias = i < tsacert.length ? tsacert[i] : null;
+            String tsaPolicyId = i < tsapolicyid.length ? tsapolicyid[i] : null;
+            tsaServersTmp.add(new TsaServer(tsaUrl, tsaAlias, tsaPolicyId, tsadigestalg));
+        }
+
         if (tsaServersTmp.isEmpty()) {
             tsaServersTmp.add(TsaServer.EMPTY);
         }
         this.tsaServers = Collections.unmodifiableList(tsaServersTmp);
     }
-
-//    private void updateTsaParameters(JarSignerSignRequest request) {
-//        if (tsa != null && tsa.length > 0) {
-//            request.setTsaLocation(tsa[0]);
-//        }
-//        if (tsacert != null && tsacert.length > 0) {
-//            request.setTsaAlias(tsacert[0]);
-//        }
-//        request.setCertchain(certchain);
-//        if (tsapolicyid != null && tsapolicyid.length > 0) {
-//            request.setTsapolicyid(tsapolicyid[0]);
-//        }
-//        request.setTsadigestalg(tsadigestalg);
-//    }
 
     /**
      * Gets the next "best" TSA server to use.
@@ -95,7 +85,7 @@ class TsaSelector {
      * Uses a "best effort" approach without any synchronization. It may not select the "snapshot-consistent" best TSA
      * server, but good enough.
      */
-    public TsaServer getServer() {
+    TsaServer getServer() {
         TsaServer bestTsaServer = tsaServers.get(0);
         for (int i = 1; i < tsaServers.size(); i++) {
             if (bestTsaServer.failureCount.get() > tsaServers.get(i).failureCount.get()) {
@@ -112,7 +102,7 @@ class TsaSelector {
      * cause of the failure it is registered as a failure for the current used TsaServer to be used when determining the
      * next TsaServer to try.
      */
-    public void registerFailure() {
+    void registerFailure() {
         if (currentTsaServer.get() != null) {
             currentTsaServer.get().failureCount.incrementAndGet();
         }
@@ -135,19 +125,19 @@ class TsaSelector {
             this.tsaDigestAlt = tsaDigestAlt;
         }
 
-        public String getTsaUrl() {
+        String getTsaUrl() {
             return tsaUrl;
         }
 
-        public String getTsaAlias() {
+        String getTsaAlias() {
             return tsaAlias;
         }
 
-        public String getTsaPolicyId() {
+        String getTsaPolicyId() {
             return tsaPolicyId;
         }
 
-        public String getTsaDigestAlt() {
+        String getTsaDigestAlt() {
             return tsaDigestAlt;
         }
     }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -91,6 +91,9 @@ class TsaSelector {
 
     /**
      * Gets the next "best" TSA server to use.
+     * 
+     * Uses a "best effort" approach without any synchronization. It may not select the "snapshot-consistent" best TSA
+     * server, but good enough.
      */
     public TsaServer getServer() {
         TsaServer bestTsaServer = tsaServers.get(0);

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -54,7 +54,7 @@ class TsaSelector {
         
     }
 
-    void updateTsaParameters(JarSignerSignRequest request) {
+    private void updateTsaParameters(JarSignerSignRequest request) {
         if (tsa != null && tsa.length > 0) {
             request.setTsaLocation(tsa[0]);
         }
@@ -68,7 +68,7 @@ class TsaSelector {
         request.setTsadigestalg(tsadigestalg);
     }
     /** Representation of a single TSA server and the parameters to use for it */
-    private class TsaServer {
+    class TsaServer {
         
     }
 }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -63,9 +63,9 @@ class TsaSelector {
         tsa = (tsa != null) ? tsa : new String[0];
         tsacert = (tsacert != null) ? tsacert : new String[0];
         tsapolicyid = (tsapolicyid != null) ? tsapolicyid : new String[0];
-        
+
         List<TsaServer> tsaServersTmp = new ArrayList<>();
-        
+
         for (int i = 0; i < Math.max(tsa.length, tsacert.length); i++) {
             String tsaUrl = i < tsa.length ? tsa[i] : null;
             String tsaAlias = i < tsacert.length ? tsacert[i] : null;
@@ -81,7 +81,7 @@ class TsaSelector {
 
     /**
      * Gets the next "best" TSA server to use.
-     * 
+     *
      * Uses a "best effort" approach without any synchronization. It may not select the "snapshot-consistent" best TSA
      * server, but good enough.
      */

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -18,10 +18,25 @@
  */
 package org.apache.maven.plugins.jarsigner;
 
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+
 class TsaSelector {
     
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
         
     }
 
+    void updateTsaParameters(JarSignerSignRequest request) {
+        if (tsa != null && tsa.length > 0) {
+            request.setTsaLocation(tsa[0]);
+        }
+        if (tsacert != null && tsacert.length > 0) {
+            request.setTsaAlias(tsacert[0]);
+        }
+        request.setCertchain(certchain);
+        if (tsapolicyid != null && tsapolicyid.length > 0) {
+            request.setTsapolicyid(tsapolicyid[0]);
+        }
+        request.setTsadigestalg(tsadigestalg);
+    }
 }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -39,4 +39,8 @@ class TsaSelector {
         }
         request.setTsadigestalg(tsadigestalg);
     }
+    /** Representation of a single TSA server and the parameters to use for it */
+    private class TsaServer {
+        
+    }
 }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -20,6 +20,34 @@ package org.apache.maven.plugins.jarsigner;
 
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
 
+/**
+ * Helper class to select a Time Stamping Authority (TSA) server along with parameters to send. The protocol is defined
+ * in RFC 3161: Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP).
+ * 
+ * From a jarsigner perspective there are two things that are important:
+ * 1. Finding a TSA server URL
+ * 2. What parameters to use for TSA server communication.
+ * 
+ * Finding a URL can be done in two ways:
+ * a) The end-user has specified an explicit URL (the most common way)
+ * b) The end-user has specified a keystore alias that points to a certificate in the active keystore. From the
+ *    certificate the X509v3 extension "Subject Information Access" field is examined to find the TSA server URL.
+ *    Example:
+ *    <pre>
+ *    [vagrant@podmanhost ~]$ openssl x509 -noout -ext subjectInfoAccess -in tsa-server.crt
+ *    Subject Information Access:
+ *        AD Time Stamping - URI:http://timestamp.globalsign.com/tsa/r6advanced1
+ *    </pre>
+ * 
+ * Each TSA server vendor typically has defined its own OID for what "policy" to use in the timestamping process. For
+ * example GlobalSign might use 1.3.6.1.4.1.4146.2.3.1.2. A DigiCert TSA server would not accept this OID. In most cases
+ * there is no need for the end-user to specify this because the TSA server will choose a default.
+ * 
+ * jarsigner will send a message digest to the TSA server along with the message digest algorithm. For example
+ * {@code SHA-384}. A TSA server might reject the chosen algorithm, but typically most TSA servers supports the "common"
+ * ones (like SHA-256, SHA-384 and SHA-512). In most cases there is no need for the end-user to specify this because the
+ * jarsigner tool choose a good default.
+ */
 class TsaSelector {
     
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -56,11 +56,22 @@ class TsaSelector {
     /** The current TsaServer in use (if any). One per thread */
     private final ThreadLocal<TsaServer> currentTsaServer = new ThreadLocal<>();
 
-    /** List of TSA servers. Will at minimum contain a dummy value */
+    /** List of TSA servers. Will at minimum contain a dummy/empty value */
     private final List<TsaServer> tsaServers;
 
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
+        tsa = (tsa != null) ? tsa : new String[0];
+        tsacert = (tsacert != null) ? tsacert : new String[0];
+        tsapolicyid = (tsapolicyid != null) ? tsapolicyid : new String[0];
+        
         List<TsaServer> tsaServersTmp = new ArrayList<>();
+        
+        for (int i == 0; i < ) // TODO
+        
+        
+        if (tsaServersTmp.isEmpty()) {
+            tsaServersTmp.add(TsaServer.EMPTY);
+        }
         this.tsaServers = Collections.unmodifiableList(tsaServersTmp);
     }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -60,10 +60,6 @@ class TsaSelector {
     private final List<TsaServer> tsaServers;
 
     TsaSelector(String[] tsa, String[] tsacert, String[] tsapolicyid, String tsadigestalg) {
-        tsa = (tsa != null) ? tsa : new String[0];
-        tsacert = (tsacert != null) ? tsacert : new String[0];
-        tsapolicyid = (tsapolicyid != null) ? tsapolicyid : new String[0];
-
         List<TsaServer> tsaServersTmp = new ArrayList<>();
 
         for (int i = 0; i < Math.max(tsa.length, tsacert.length); i++) {

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -83,10 +83,22 @@ class TsaSelector {
      * Gets the next "best" TSA server to use.
      */
     public TsaServer getServer() {
-        // TODO Auto-generated method stub
-        return null;
+        TsaServer bestTsaServer = tsaServers.get(0);
+        for (int i = 1; i < tsaServers.size(); i++) {
+            if (bestTsaServer.failureCount.get() > tsaServers.get(i).failureCount.get()) {
+                bestTsaServer = tsaServers.get(i);
+            }
+        }
+        currentTsaServer.set(bestTsaServer);
+        return bestTsaServer;
     }
 
+    /**
+     * Register that the current used TsaServer was involved in a jarsigner execution that failed. This could be a
+     * problem with the TsaServer, but it could also be other factors unrelated to the TsaServer. Regardless of the
+     * cause of the failure it is registered as a failure for the current used TsaServer to be used when determining the
+     * next TsaServer to try.
+     */
     public void registerFailure() {
         if (currentTsaServer.get() != null) {
             currentTsaServer.get().failureCount.incrementAndGet();

--- a/src/main/resources/jarsigner.properties
+++ b/src/main/resources/jarsigner.properties
@@ -27,3 +27,7 @@ archiveNotSigned = Archive ''{0}'' is not signed
 invalidMaxTries = Invalid maxTries value. Was ''{0}'' but should be >= 1
 invalidMaxRetryDelaySeconds = Invalid maxRetryDelaySeconds value. Was ''{0}'' but should be >= 0
 invalidThreadCount = Invalid threadCount value. Was ''{0}'' but should be >= 1
+warnUsageTsaAndTsacertSimultaneous = Usage of both -tsa and -tsacert is undefined
+warnUsageTsapolicyidTooMany = Too many ({0}) number of OIDs given, but only {1} and {2} TSA URL and TSA certificate alias, respectively
+warnUsageMultiTsaWithoutRetry = {0} TSA URLs specified. Only first will be used because maxTries is set to 1
+warnUsageMultiTsacertWithoutRetry = {0} TSA certificate aliases specified. Only first will be used because maxTries is set to 1

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -156,7 +156,7 @@ public class JarsignerSignMojoTsaTest {
 
         mojo.execute();
 
-        verify(log).warn(contains("Too many (3) number of OIDs given, but only 2 and 0 TSA URL and TSA certificate alias, respectively"));
+        verify(log).warn(contains("Too many (3) number of OIDs given"));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class JarsignerSignMojoTsaTest {
         mojo.execute();
 
         // Alomst the same warning log as previous test case
-        verify(log).warn(contains("Too many (3) number of OIDs given, but only 0 and 2 TSA URL and TSA certificate alias, respectively"));
+        verify(log).warn(contains("Too many (3) number of OIDs given"));
     }
 
     @Test
@@ -194,7 +194,7 @@ public class JarsignerSignMojoTsaTest {
 
         mojo.execute();
 
-        verify(log).warn(contains("2 TSA certificate aliases specified. Only first will be used because maxTries is set to 1"));
+        verify(log).warn(contains("2 TSA certificate aliases specified. Only first"));
     }
 
     private File createArchives(int numberOfArchives) throws IOException {

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -138,6 +138,7 @@ public class JarsignerSignMojoTsaTest {
     @Test
     public void testVerifyUsageOfBothTsaAndTsacert() throws Exception {
         when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("maxTries", "2");
         configuration.put("tsa", "http://my-timestamp.server.com");
         configuration.put("tsacert", "mytsacertalias");
         JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
@@ -150,6 +151,7 @@ public class JarsignerSignMojoTsaTest {
     @Test
     public void testVerifyUsageOfDifferentNumberOfTsapolicyidAndTsa() throws Exception {
         when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("maxTries", "2");
         configuration.put("tsa", "http://my-timestamp1.server.com,http://my-timestamp2.server.com");
         configuration.put("tsapolicyid", "1.2.3.4"); // Too few OIDs specified
         JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
@@ -162,6 +164,7 @@ public class JarsignerSignMojoTsaTest {
     @Test
     public void testVerifyUsageOfDifferentNumberOfTsapolicyidAndTsacert() throws Exception {
         when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("maxTries", "2");
         configuration.put("tsacert", "alias1,alisa2");
         configuration.put("tsapolicyid", "1.2.3.4"); // Too few OIDs specified
         JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.jarsigner.JarsignerSignMojo.Sleeper;
+import org.apache.maven.plugins.jarsigner.JarsignerSignMojo.WaitStrategy;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.everyItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JarsignerSignMojoTsaTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private MavenProject project = mock(MavenProject.class);
+    private JarSigner jarSigner = mock(JarSigner.class);
+
+    private File projectDir;
+    private Map<String, String> configuration = new LinkedHashMap<>();
+    private Log log;
+    private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
+
+    @Before
+    public void setUp() throws Exception {
+        projectDir = folder.newFolder("dummy-project");
+        mojoTestCreator =
+                new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
+        log = mock(Log.class);
+        mojoTestCreator.setLog(log);
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+    }
+
+    @Test
+    public void testAllTsaParameters() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("archiveDirectory", createArchives(2).getPath());
+        configuration.put("tsa", "http://my-timestam.server.com");
+        configuration.put("tsacert", "mytsacertalias"); // Normally you would not set both "tsacert alias" and "tsa url"
+        configuration.put("tsapolicyid", "0.1.2.3.4");
+        configuration.put("tsadigestalg", "SHA-384");
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<JarSignerSignRequest> requestArgument = ArgumentCaptor.forClass(JarSignerSignRequest.class);
+        verify(jarSigner, times(3)).execute(requestArgument.capture());
+        List<JarSignerSignRequest> requests = requestArgument.getAllValues();
+        assertThat(requests, everyItem(RequestMatchers.hasTsa("http://my-timestam.server.com")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsacert("mytsacertalias")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsaPolicyid("0.1.2.3.4")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsaDigestalg("SHA-384")));
+    }
+
+    private File createArchives(int numberOfArchives) throws IOException {
+        File archiveDirectory = new File(projectDir, "my_archive_dir");
+        archiveDirectory.mkdir();
+        for (int i = 0; i < numberOfArchives; i++) {
+            TestArtifacts.createDummyZipFile(new File(archiveDirectory, "archive" + i + ".jar"));
+        }
+        return archiveDirectory;
+    }
+
+}
+

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -122,6 +122,8 @@ public class JarsignerSignMojoTsaTest {
         assertEquals("http://other-timestamp.example.com", tsaUrls.get(1));
     }
 
+    // TODO: Add verification tests
+
     private File createArchives(int numberOfArchives) throws IOException {
         File archiveDirectory = new File(projectDir, "my_archive_dir");
         archiveDirectory.mkdir();

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -98,7 +98,7 @@ public class JarsignerSignMojoTsaTest {
         ArgumentCaptor<JarSignerSignRequest> requestArgument = ArgumentCaptor.forClass(JarSignerSignRequest.class);
         verify(jarSigner, times(3)).execute(requestArgument.capture());
         List<JarSignerSignRequest> requests = requestArgument.getAllValues();
-        assertThat(requests, everyItem(RequestMatchers.hasTsa("http://my-timestam.server.com")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsa("http://my-timestamp.server.com")));
         assertThat(requests, everyItem(RequestMatchers.hasTsacert("mytsacertalias")));
         assertThat(requests, everyItem(RequestMatchers.hasTsaPolicyid("0.1.2.3.4")));
         assertThat(requests, everyItem(RequestMatchers.hasTsaDigestalg("SHA-384")));

--- a/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
@@ -125,7 +125,7 @@ public class MojoTestCreator<T extends AbstractJarsignerMojo> {
             field.set(instance, new File(stringValue));
         } else if (fieldType.equals(String[].class)) {
             if (stringValue.isEmpty()) {
-                // Maven defaults empty list if no default value exists
+                // Maven defaults to empty list if no default value exists
                 field.set(instance, new String[0]);
             } else {
                 String[] values = stringValue.split(",");

--- a/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
@@ -124,8 +124,13 @@ public class MojoTestCreator<T extends AbstractJarsignerMojo> {
         } else if (fieldType.equals(File.class)) {
             field.set(instance, new File(stringValue));
         } else if (fieldType.equals(String[].class)) {
-            String[] values = stringValue.split(",");
-            field.set(instance, values);
+            if (stringValue.isEmpty()) {
+                // Maven defaults empty list if no default value exists
+                field.set(instance, new String[0]);
+            } else {
+                String[] values = stringValue.split(",");
+                field.set(instance, values);
+            }
         } else {
             if (!stringValue.startsWith("${")) {
                 logger.warn(

--- a/src/test/java/org/apache/maven/plugins/jarsigner/PluginXmlParser.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/PluginXmlParser.java
@@ -68,6 +68,14 @@ public class PluginXmlParser {
             if (configurationElement.hasAttribute(CONF_DEFAULT_VALUE)) {
                 String defaultValue = configurationElement.getAttribute(CONF_DEFAULT_VALUE);
                 defaultConfiguration.put(configurationParameterName, defaultValue);
+            } else {
+                if (configurationElement.hasAttribute("implementation")) {
+                    String implementation = configurationElement.getAttribute("implementation");
+                    // String arrays are per default set to empty array if user does not configure them
+                    if ("java.lang.String[]".equals(implementation)) {
+                        defaultConfiguration.put(configurationParameterName, "");
+                    }
+                }
             }
         }
         return defaultConfiguration;

--- a/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
@@ -185,6 +185,16 @@ class RequestMatchers {
                 "has tsacert ", tsacert, request -> request.getTsaAlias().equals(tsacert));
     }
 
+    static TypeSafeMatcher<JarSignerSignRequest> hasTsaPolicyid(String tsapolicyid) {
+        return new JarSignerSignRequestMatcher(
+                "has tsapolicyid ", tsapolicyid, request -> request.getTsapolicyid().equals(tsapolicyid));
+    }
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasTsaDigestalg(String tsadigestalg) {
+        return new JarSignerSignRequestMatcher(
+                "has tsadigestalg ", tsadigestalg, request -> request.getTsadigestalg().equals(tsadigestalg));
+    }
+
     static TypeSafeMatcher<JarSignerSignRequest> hasCertchain(String certchain) {
         return new JarSignerSignRequestMatcher("has certchain ", certchain, request -> request.getCertchain()
                 .getPath()

--- a/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
@@ -186,13 +186,13 @@ class RequestMatchers {
     }
 
     static TypeSafeMatcher<JarSignerSignRequest> hasTsaPolicyid(String tsapolicyid) {
-        return new JarSignerSignRequestMatcher(
-                "has tsapolicyid ", tsapolicyid, request -> request.getTsapolicyid().equals(tsapolicyid));
+        return new JarSignerSignRequestMatcher("has tsapolicyid ", tsapolicyid, request -> request.getTsapolicyid()
+                .equals(tsapolicyid));
     }
 
     static TypeSafeMatcher<JarSignerSignRequest> hasTsaDigestalg(String tsadigestalg) {
-        return new JarSignerSignRequestMatcher(
-                "has tsadigestalg ", tsadigestalg, request -> request.getTsadigestalg().equals(tsadigestalg));
+        return new JarSignerSignRequestMatcher("has tsadigestalg ", tsadigestalg, request -> request.getTsadigestalg()
+                .equals(tsadigestalg));
     }
 
     static TypeSafeMatcher<JarSignerSignRequest> hasCertchain(String certchain) {

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.plugins.jarsigner;
 
-import static org.junit.Assert.*;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,6 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.maven.plugins.jarsigner.TsaSelector.TsaServer;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TsaSelectorTest {
 
@@ -45,7 +45,7 @@ public class TsaSelectorTest {
         assertNull(tsaServer.getTsaPolicyId());
         assertNull(tsaServer.getTsaDigestAlt());
 
-        //Make sure "next" server also contains null values
+        // Make sure "next" server also contains null values
         tsaServer = tsaSelector.getServer();
         assertNull(tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
@@ -56,7 +56,7 @@ public class TsaSelectorTest {
     @Test
     public void testFailureCount() {
         tsaSelector = new TsaSelector(
-                new String[]{"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
 
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
@@ -72,7 +72,7 @@ public class TsaSelectorTest {
         assertNull(tsaServer.getTsaPolicyId());
         assertNull(tsaServer.getTsaDigestAlt());
 
-        //Should get same server again
+        // Should get same server again
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url2.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
@@ -85,7 +85,7 @@ public class TsaSelectorTest {
         executor = Executors.newFixedThreadPool(2);
 
         tsaSelector = new TsaSelector(
-            new String[]{"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
 
         // Register a single failure on the first URL so that the threads will use URL 2
         TsaServer serverThreadMain = tsaSelector.getServer();
@@ -129,14 +129,15 @@ public class TsaSelectorTest {
 
     @Test
     public void testDigestAlgoritm() {
-        tsaSelector = new TsaSelector(new String[]{"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, "SHA-512");
+        tsaSelector = new TsaSelector(
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, "SHA-512");
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
         assertEquals("SHA-512", tsaServer.getTsaDigestAlt());
 
-        //Make sure that the next URL has the same digest algorithm
+        // Make sure that the next URL has the same digest algorithm
         tsaSelector.registerFailure();
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url2.com", tsaServer.getTsaUrl());
@@ -147,7 +148,7 @@ public class TsaSelectorTest {
 
     @Test
     public void testKeyStoreAliasAndOid() {
-        tsaSelector = new TsaSelector(null, new String[]{"alias1", "alias2"}, new String[]{"1.1", "1.2"}, null);
+        tsaSelector = new TsaSelector(null, new String[] {"alias1", "alias2"}, new String[] {"1.1", "1.2"}, null);
         tsaServer = tsaSelector.getServer();
         assertNull(tsaServer.getTsaUrl());
         assertEquals("alias1", tsaServer.getTsaAlias());
@@ -162,7 +163,8 @@ public class TsaSelectorTest {
 
     @Test
     public void testFailureRegistrationWithoutCurrent() {
-        tsaSelector = new TsaSelector(new String[]{"http://url1.com"}, new String[]{"alias1"}, new String[]{"1.1"}, "SHA-384");
+        tsaSelector = new TsaSelector(
+                new String[] {"http://url1.com"}, new String[] {"alias1"}, new String[] {"1.1"}, "SHA-384");
         tsaSelector.registerFailure(); // Should not throw any exception
 
         // Make sure further execution works

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -91,7 +91,7 @@ public class TsaSelectorTest {
         TsaServer serverThreadMain = tsaSelector.getServer();
         tsaSelector.registerFailure();
 
-        CountDownLatch doneSignal = new CountDownLatch(2); // Indication that both thread has gotten a server
+        CountDownLatch doneSignal = new CountDownLatch(2); // Indication that both threads has gotten a server
         Semaphore semaphore = new Semaphore(0); // When the threads may continue executing after gotten a server
 
         AtomicReference<TsaServer> serverThread1 = new AtomicReference<>();
@@ -119,7 +119,7 @@ public class TsaSelectorTest {
         assertEquals("http://url2.com", serverThread1.get().getTsaUrl());
         assertEquals("http://url2.com", serverThread2.get().getTsaUrl());
 
-        // The next best URL is number 3
+        // The best URL is now number 3
         assertEquals("http://url3.com", tsaSelector.getServer().getTsaUrl());
 
         // Trigger a new failure, now URL 1 is best again.

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -1,0 +1,14 @@
+package org.apache.maven.plugins.jarsigner;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TsaSelectorTest {
+
+    @Test
+    public void test() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.plugins.jarsigner;
 
 import static org.junit.Assert.*;
@@ -73,10 +91,9 @@ public class TsaSelectorTest {
         // Register a single failure on the first URL so that the threads will use URL 2
         TsaServer serverThreadMain = tsaSelector.getServer();
         tsaSelector.registerFailure();
-        
 
-        CountDownLatch doneSignal = new CountDownLatch(2);
-        Semaphore semaphore = new Semaphore(0);
+        CountDownLatch doneSignal = new CountDownLatch(2); // Indication that both thread has gotten a server
+        Semaphore semaphore = new Semaphore(0); // When the threads may continue executing after gotten a server
 
         AtomicReference<TsaServer> serverThread1 = new AtomicReference();
         AtomicReference<TsaServer> serverThread2 = new AtomicReference();

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -31,14 +31,14 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class TsaSelectorTest {
-
+    private static final String[] EMPTY = new String[0];
     private TsaSelector tsaSelector;
     private TsaServer tsaServer;
     private ExecutorService executor;
 
     @Test
     public void testNullInit() {
-        tsaSelector = new TsaSelector(null, null, null, null);
+        tsaSelector = new TsaSelector(EMPTY, EMPTY, EMPTY, null);
         tsaServer = tsaSelector.getServer();
         assertNull(tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
@@ -56,7 +56,7 @@ public class TsaSelectorTest {
     @Test
     public void testFailureCount() {
         tsaSelector = new TsaSelector(
-                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, EMPTY, EMPTY, null);
 
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
@@ -85,7 +85,7 @@ public class TsaSelectorTest {
         executor = Executors.newFixedThreadPool(2);
 
         tsaSelector = new TsaSelector(
-                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, null);
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, EMPTY, EMPTY, null);
 
         // Register a single failure on the first URL so that the threads will use URL 2
         TsaServer serverThreadMain = tsaSelector.getServer();
@@ -130,7 +130,7 @@ public class TsaSelectorTest {
     @Test
     public void testDigestAlgoritm() {
         tsaSelector = new TsaSelector(
-                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, null, null, "SHA-512");
+                new String[] {"http://url1.com", "http://url2.com", "http://url3.com"}, EMPTY, EMPTY, "SHA-512");
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
@@ -148,7 +148,7 @@ public class TsaSelectorTest {
 
     @Test
     public void testKeyStoreAliasAndOid() {
-        tsaSelector = new TsaSelector(null, new String[] {"alias1", "alias2"}, new String[] {"1.1", "1.2"}, null);
+        tsaSelector = new TsaSelector(EMPTY, new String[] {"alias1", "alias2"}, new String[] {"1.1", "1.2"}, null);
         tsaServer = tsaSelector.getServer();
         assertNull(tsaServer.getTsaUrl());
         assertEquals("alias1", tsaServer.getTsaAlias());

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -2,13 +2,57 @@ package org.apache.maven.plugins.jarsigner;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+
+import org.apache.maven.plugins.jarsigner.TsaSelector.TsaServer;
 import org.junit.Test;
 
 public class TsaSelectorTest {
+    
+    private TsaSelector tsaSelector;
+    private TsaServer tsaServer;
 
     @Test
-    public void test() {
-        fail("Not yet implemented");
+    public void testNullInit() {
+        tsaSelector = new TsaSelector(null, null, null, null);
+        tsaServer = tsaSelector.getServer();
+        assertNull(tsaServer.getTsaUrl());
+        assertNull(tsaServer.getTsaAlias());
+        assertNull(tsaServer.getTsaPolicyId());
+        assertNull(tsaServer.getTsaDigestAlt());
+
+        //Make sure "next" server also contains null values
+        tsaServer = tsaSelector.getServer();
+        assertNull(tsaServer.getTsaUrl());
+        assertNull(tsaServer.getTsaAlias());
+        assertNull(tsaServer.getTsaPolicyId());
+        assertNull(tsaServer.getTsaDigestAlt());
     }
 
+    @Test
+    public void testFailureCount() {
+        tsaSelector = new TsaSelector(
+                new String[]{"http://url1.com", "http://url2.com", "http://url2.com"}, null, null, null);
+
+        tsaServer = tsaSelector.getServer();
+        assertEquals("http://url1.com", tsaServer.getTsaUrl());
+        assertNull(tsaServer.getTsaAlias());
+        assertNull(tsaServer.getTsaPolicyId());
+        assertNull(tsaServer.getTsaDigestAlt());
+        
+        tsaSelector.registerFailure();
+        
+        tsaServer = tsaSelector.getServer();
+        assertEquals("http://url2.com", tsaServer.getTsaUrl());
+        assertNull(tsaServer.getTsaAlias());
+        assertNull(tsaServer.getTsaPolicyId());
+        assertNull(tsaServer.getTsaDigestAlt());
+
+        //Should get same server again
+        tsaServer = tsaSelector.getServer();
+        assertEquals("http://url2.com", tsaServer.getTsaUrl());
+        assertNull(tsaServer.getTsaAlias());
+        assertNull(tsaServer.getTsaPolicyId());
+        assertNull(tsaServer.getTsaDigestAlt());
+    }
 }


### PR DESCRIPTION
Implementation of support for multiple TSA servers. A new server will be tried if the jarsigner command fails. The failure could be with communication with the TSA server, or could be something unrelated to TSA (for example access to a network based PKSC11 keystore).

I have also implemented support for:

1. Specifying multiple TSA keystore aliases as an alternative to specifying TSA URLs directly
2. Specify `tsapolicyid` OID(s) to send to the TSA server(s)
3. Specify the message digest algorithm (`tsadigestalg`) to use in communication with the TSA server (no multi-support, only one value for all TSA servers).

The hardest thing working with this ticket was to figure out what should be possible to configure from an end user perspective. This is what I came up with (and would like feedback on):

1. I did not see any need to throw an exception (abort the Mojo) if the end user configured something that I consider "wrong". Instead I have logged warnings when this happens
2. Setting both `tsa` and `tsacert` seems wrong. At least jarsigner will ignore `-tsacert` if `-tsa` is set. However from a bigger perspective it might be possible for the end user to want to configure 1 TSA url and 2 keystore alias as to try 3 TSA servers in total? But this scenario felt too complicated to document and specify, so I skipped it.
3. As I tested this feature against public TSA servers it became clear that they will typically have a dedicated, vendor specific OID. For example http://timestamp.digicert.com will only accept the DigiCert created [OID 2.16.840.1.114412.7.1](http://www.oid-info.com/cgi-bin/display?oid=2.16.840.1.114412.7&submit=Display&action=display). I therefore tried to document that the number of OIDs specified by the end user should be the same as the number of TSA servers the user wants to try.
4. For `tsadigestalg` on the other hand I did not see any need to specify multiple. All TSA servers will handle the most common message digest algorithms.
5. The usage of `tsacert`,  `tsapolicyid` and `tsadigestalg` is probably obscure. I'm not sure anybody is interested in using these features. It took me many hours before I could create a testing keystore that contained a valid certificate to use. And it took me some additions hours to figure out what OIDs to use. It was only after using Wireshark to sniff the traffic that I understood how the protocol in RFC 3161 worked.

**Note:** this pull request can not be merged until a new release build of https://github.com/apache/maven-jarsigner has been made.